### PR TITLE
Make all sliders move to the left mouse click position

### DIFF
--- a/app/ui/core/proxy_style.py
+++ b/app/ui/core/proxy_style.py
@@ -1,0 +1,10 @@
+from PySide6 import QtWidgets
+from PySide6.QtCore import Qt
+
+
+class ProxyStyle(QtWidgets.QProxyStyle):
+    def styleHint(self, hint, opt=None, widget=None, returnData=None) -> int:
+        res = super().styleHint(hint, opt, widget, returnData)
+        if hint == self.StyleHint.SH_Slider_AbsoluteSetButtons:
+            res = Qt.LeftButton.value
+        return res

--- a/main.py
+++ b/main.py
@@ -3,10 +3,12 @@ from PySide6 import QtWidgets
 import sys
 
 import qdarktheme
+from app.ui.core.proxy_style import ProxyStyle
 
 if __name__=="__main__":
 
     app = QtWidgets.QApplication(sys.argv)
+    app.setStyle(ProxyStyle())
     with open("app/ui/styles/dark_styles.qss", "r") as f:
         _style = f.read()
         _style = qdarktheme.load_stylesheet(custom_colors={"primary": "#4facc9"})+'\n'+_style


### PR DESCRIPTION
This change makes all sliders in the app to handle left mouse click out of the slider button as a new slider position.