### PR TITLE
Update onnxruntime-gpu to 1.22.0

### DIFF
--- a/requirements_cu124.txt
+++ b/requirements_cu124.txt
@@ -7,7 +7,7 @@ pillow==9.5.0
 onnx==1.16.1
 protobuf==4.23.2
 psutil==6.0.0
-onnxruntime-gpu==1.20.0
+onnxruntime-gpu==1.22.0
 packaging==24.1
 PySide6==6.8.2.1 
 kornia


### PR DESCRIPTION
The update is applied only to Cuda 12.4 requirements.txt

This change fixes https://github.com/visomaster/VisoMaster/issues/64